### PR TITLE
simplified API.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: kemal_jwt_auth
-version: 0.1.0
+version: 1.0.0
 
 authors:
   - D. Scott Boggs <scott@tams.tech>

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -18,13 +18,17 @@ struct ExampleUser
 end
 
 struct UserData
-  @internal = [] of ExampleUser
+  include KemalJWTAuth::UsersCollection
+  @internal : Array(ExampleUser)
 
-  def initialize(users @internal); end
+  def initialize(users @internal : Array(ExampleUser)); end
 
   def self.from_json(data) : self
-    @internal.from_json data
+    new users: Array(ExampleUser).from_json data
   end
+
+  delegate :to_json, to: @internal
+  forward_missing_to @internal
 
   def find_and_authenticate!(from data) : ExampleUser?
     user = Hash(String, String).from_json data

--- a/src/handler.cr
+++ b/src/handler.cr
@@ -1,9 +1,10 @@
 require "jwt"
 require "kemal"
 require "logger"
+require "./users_collection"
 
 # JWT authorization middleware
-class KemalJWTAuth::Handler(UsersCollection, User) < Kemal::Handler
+class KemalJWTAuth::Handler < Kemal::Handler
   # Used to encrypt all JWTs
   private property secret_key : String
   @logger : Logger

--- a/src/kemal_jwt_auth.cr
+++ b/src/kemal_jwt_auth.cr
@@ -1,6 +1,9 @@
 require "./core_ext/**"
 require "./*"
 
+# This is the format stored in the JWT for later retrieval -- it is a limited
+# subset of JSON. If you can't store your data in this structure, you have to
+# serialize it in some other way, then store that as a string member.
 alias UserHash = Hash(String, (String | Int32 | Nil | Bool))
 
 module KemalJWTAuth

--- a/src/users_collection.cr
+++ b/src/users_collection.cr
@@ -1,0 +1,10 @@
+module KemalJWTAuth::UsersCollection
+  # A UsersCollection must return an authenticated user from this method, or
+  # nil in the case of failed authentication. The body is the body received
+  # from `HTTP::Request#body` -- a non-nil IO (in the case where the body
+  # is nil, this method is not called.)
+  abstract def find_and_authenticate!(body : IO)
+  # It actually needs `self.from_json` but you can't define an abstract class
+  # method
+  abstract def to_json
+end


### PR DESCRIPTION
It was not necessary to make the Handler a generic, we just UsersCollection to implement a certain interface. The compiler understands this by using an included Module to represent an interface satisfied by the type the module is included on, which may be a class, struct or other module.